### PR TITLE
fix: raw.riot の innerHTML に sanitizeHtml を適用し XSS シンクを解消

### DIFF
--- a/src/components/raw.riot
+++ b/src/components/raw.riot
@@ -1,8 +1,10 @@
 <raw>
   <script>
+    import { sanitizeHtml } from '@/utils/sanitize';
+
     export default {
       setInnerHTML() {
-        this.root.innerHTML = this.props.html;
+        this.root.innerHTML = sanitizeHtml(this.props.html ?? '');
       },
       onMounted() {
         this.setInnerHTML();


### PR DESCRIPTION
呼び出し側のサニタイズに依存していた設計を改め、コンポーネント自体が
DOMPurify ベースの sanitizeHtml を通してから innerHTML に代入するように変更。 将来サニタイズ忘れの呼び出しが追加されても XSS にならない。

https://claude.ai/code/session_01XGNDj9PcEGGZx5QMGtEjEc