### PR TITLE
fix: Stripe Webhook のメール所有権未確認による premium 付与を修正

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -176,42 +176,54 @@ export const stripeWebhook = onRequest(
 
       case 'checkout.session.completed': {
         const session = event.data.object as Stripe.Checkout.Session;
-        const email = session.customer_details?.email;
-        if (!email || !session.subscription) break;
+        if (!session.subscription) break;
 
-        // メールアドレスから Firebase Auth ユーザーを特定/作成
+        const customerId = session.customer as string;
         let uid: string;
-        try {
-          const userRecord = await admin.auth().getUserByEmail(email);
-          uid = userRecord.uid;
-        } catch (err: any) {
-          if (err.code !== 'auth/user-not-found') {
-            // ネットワーク障害・レートリミット等の一時的エラーは 500 を返し Stripe にリトライさせる
-            console.error(`getUserByEmail failed for ${email}:`, err.code, err.message);
-            res.status(500).json({ received: false, error: 'Failed to look up user' });
+
+        if (session.client_reference_id) {
+          // ログイン済みユーザーが Payment Link に ?client_reference_id=<uid> を付けて決済した場合。
+          // メール所有権の確認不要（Firebase Auth で認証済みの uid を直接使う）。
+          try {
+            await admin.auth().getUser(session.client_reference_id);
+            uid = session.client_reference_id;
+          } catch (err: any) {
+            console.error(`Invalid client_reference_id: ${session.client_reference_id}`, err.code);
+            res.status(400).json({ received: false, error: 'Invalid client_reference_id' });
             return;
           }
-          // 【設計上の意図】emailVerified: false のまま premium を付与する
-          //
-          // このフローでは Stripe がチェックアウト時にメールアドレスの実在を担保している。
-          // Stripe は決済完了メールをそのアドレスに送付するため、到達不能なメールへの
-          // 決済は事実上不可能であり、Firebase のメール確認と同等の信頼性がある。
-          //
-          // また、マジックリンク（sendSignInLinkToEmail）でサインインした時点で
-          // Firebase Auth は自動的に emailVerified を true に更新するため、
-          // 初回ログイン後にこのフラグは解消される。
-          //
-          // よって、メール確認を premium 付与の前提条件にすることはしない。
-          // 決済完了 = メール実在確認 として扱う。
-          const newUser = await admin.auth().createUser({
-            email,
-            emailVerified: false,
-          });
-          uid = newUser.uid;
+        } else {
+          // フォールバック: 未ログインユーザーや client_reference_id なしの決済はメールで特定する。
+          const email = session.customer_details?.email;
+          if (!email) break;
+
+          try {
+            const userRecord = await admin.auth().getUserByEmail(email);
+            uid = userRecord.uid;
+
+            // 既存ユーザーが別の Stripe Customer にすでに紐づいている場合、
+            // 攻撃者が被害者メールを使って決済した可能性があるため上書きを拒否する。
+            const existingDoc = await db.collection('users').doc(uid).get();
+            const existingCustomerId = existingDoc.data()?.stripeCustomerId as string | undefined;
+            if (existingCustomerId && existingCustomerId !== customerId) {
+              console.warn(
+                `checkout.session.completed: uid=${uid} already linked to ${existingCustomerId}, rejecting ${customerId}. Possible account takeover attempt.`,
+              );
+              res.status(200).json({ received: true, skipped: true });
+              return;
+            }
+          } catch (err: any) {
+            if (err.code !== 'auth/user-not-found') {
+              console.error(`getUserByEmail failed for ${email}:`, err.code, err.message);
+              res.status(500).json({ received: false, error: 'Failed to look up user' });
+              return;
+            }
+            const newUser = await admin.auth().createUser({ email, emailVerified: false });
+            uid = newUser.uid;
+          }
         }
 
         // Stripe Customer に firebaseUID を保存（以降の Webhook で参照）
-        const customerId = session.customer as string;
         await stripe.customers.update(customerId, {
           metadata: { firebaseUID: uid },
         });

--- a/src/components/premium-gate.riot
+++ b/src/components/premium-gate.riot
@@ -45,13 +45,14 @@
 
   <script>
     import membershipStore from '@/stores/membership-store';
+    import authStore from '@/stores/auth-store';
     import i18nStore from '@/stores/i18n-store';
 
     export default {
       t: i18nStore.t.bind(i18nStore),
       state: {
-        monthlyPaymentLinkUrl: membershipStore.getMonthlyPaymentLinkUrl(),
-        yearlyPaymentLinkUrl: membershipStore.getYearlyPaymentLinkUrl(),
+        monthlyPaymentLinkUrl: membershipStore.getMonthlyPaymentLinkUrl(authStore.user?.uid),
+        yearlyPaymentLinkUrl: membershipStore.getYearlyPaymentLinkUrl(authStore.user?.uid),
         monthlyPrice: membershipStore.getFormattedMonthlyPrice(),
         yearlyPrice: membershipStore.getFormattedYearlyPrice(),
         activeTab: membershipStore.getMonthlyPaymentLinkUrl() ? 'monthly'
@@ -60,19 +61,27 @@
       },
       onMounted() {
         this._handlePricingChanged = () => {
-          console.log("-------")
           this.update({
             monthlyPrice: membershipStore.getFormattedMonthlyPrice(),
             yearlyPrice: membershipStore.getFormattedYearlyPrice(),
           });
         };
+        this._handleAuthChanged = () => {
+          this.update({
+            monthlyPaymentLinkUrl: membershipStore.getMonthlyPaymentLinkUrl(authStore.user?.uid),
+            yearlyPaymentLinkUrl: membershipStore.getYearlyPaymentLinkUrl(authStore.user?.uid),
+          });
+        };
         membershipStore.on('pricing-changed', this._handlePricingChanged);
-        // 既にデータがロード済みの場合に反映
+        authStore.on('auth-changed', this._handleAuthChanged);
         this._handlePricingChanged();
       },
       onBeforeUnmount() {
         if (this._handlePricingChanged) {
           membershipStore.off('pricing-changed', this._handlePricingChanged);
+        }
+        if (this._handleAuthChanged) {
+          authStore.off('auth-changed', this._handleAuthChanged);
         }
       },
     }

--- a/src/pages/account.riot
+++ b/src/pages/account.riot
@@ -183,8 +183,8 @@
       onBeforeMount() {
         // state の静的定義はモジュール import 時（authStore.init() 前）に評価されるため
         // 初回レンダリング前に store の最新値で上書きする
-        const monthly = membershipStore.getMonthlyPaymentLinkUrl();
-        const yearly = membershipStore.getYearlyPaymentLinkUrl();
+        const monthly = membershipStore.getMonthlyPaymentLinkUrl(authStore.user?.uid);
+        const yearly = membershipStore.getYearlyPaymentLinkUrl(authStore.user?.uid);
         Object.assign(this.state, {
           user: authStore.user,
           avatarUrl: authStore.getAvatarUrl(),
@@ -232,8 +232,8 @@
         router.push('/');
       },
       onAuthChanged() {
-        const monthly = membershipStore.getMonthlyPaymentLinkUrl();
-        const yearly = membershipStore.getYearlyPaymentLinkUrl();
+        const monthly = membershipStore.getMonthlyPaymentLinkUrl(authStore.user?.uid);
+        const yearly = membershipStore.getYearlyPaymentLinkUrl(authStore.user?.uid);
         this.update({
           user: authStore.user,
           avatarUrl: authStore.getAvatarUrl(),

--- a/src/stores/membership-store.ts
+++ b/src/stores/membership-store.ts
@@ -33,29 +33,24 @@ interface MembershipStore extends ObservableInstance<unknown> {
    */
   isEpisodePremium(episodeId: string): boolean | null;
   /**
-   * Payment Link URL を返す
-   *
-   * 設計方針: client_reference_id を使わず、Webhook 側でメールアドレスからユーザーを特定
-   *
-   * 理由:
-   * - Stripe Payment Links は client_reference_id をサポートしていない
-   * - メールアドレスは Checkout Session から確実に取得できる
-   *
-   * トレードオフと制限:
-   * - メールアドレス変更時: 初回決済時のメールで Firebase Auth ユーザーを作成/特定するため、
-   *   その後ユーザーがメールアドレスを変更しても、Stripe Customer の metadata に保存した
-   *   firebaseUID で継続的に追跡可能（metadata は stripeWebhook で自動設定される）
-   * - 異なるメールでの再購入: 新しいメールアドレスで決済した場合、別の Firebase Auth
-   *   ユーザーとして扱われる（これは意図的な動作）
-   * - メールアドレスの一意性: Firebase Auth のメール認証を前提としているため、同じメール
-   *   アドレスで複数のユーザーが作成されることはない
+   * Payment Link URL を返す。uid を渡すと ?client_reference_id=<uid> を付与し、
+   * Webhook 側でメール検索を経由せず直接 Firebase UID でユーザーを特定できる。
+   * 未ログインの場合は uid なしでそのまま返す（Webhook 側でメール検索フォールバック）。
    */
-  getMonthlyPaymentLinkUrl(): string | null;
-  getYearlyPaymentLinkUrl(): string | null;
+  getMonthlyPaymentLinkUrl(uid?: string | null): string | null;
+  getYearlyPaymentLinkUrl(uid?: string | null): string | null;
   getCustomerPortalUrl(): string | null;
   getFormattedMonthlyPrice(): string | null;
   getFormattedYearlyPrice(): string | null;
   destroy(): void;
+}
+
+function buildPaymentUrl(baseUrl: string, uid?: string | null): string | null {
+  if (!baseUrl) return null;
+  if (!uid) return baseUrl;
+  const url = new URL(baseUrl);
+  url.searchParams.set('client_reference_id', uid);
+  return url.toString();
 }
 
 const membershipStore = observable({
@@ -108,12 +103,12 @@ const membershipStore = observable({
     return this.premiumEpisodeIds.has(episodeId);
   },
 
-  getMonthlyPaymentLinkUrl(): string | null {
-    return MONTHLY_PAYMENT_LINK_URL || null;
+  getMonthlyPaymentLinkUrl(uid?: string | null): string | null {
+    return buildPaymentUrl(MONTHLY_PAYMENT_LINK_URL, uid);
   },
 
-  getYearlyPaymentLinkUrl(): string | null {
-    return YEARLY_PAYMENT_LINK_URL || null;
+  getYearlyPaymentLinkUrl(uid?: string | null): string | null {
+    return buildPaymentUrl(YEARLY_PAYMENT_LINK_URL, uid);
   },
 
   getCustomerPortalUrl(): string | null {


### PR DESCRIPTION
【攻撃シナリオ】
攻撃者が被害者のメールアドレスを Stripe チェックアウトに入力して決済すると、
Webhook がそのメールで既存 Firebase ユーザーを引き当て、
被害者の stripeCustomerId を攻撃者の Stripe Customer で上書きしていた。

【対策】

1. Payment Link に ?client_reference_id=<firebase_uid> を付与（フロント）
   - membership-store: buildPaymentUrl() で uid を URL に埋め込む
   - account.riot / premium-gate.riot: authStore.user.uid を渡す

2. Webhook で client_reference_id を第一優先で使用（functions）
   - client_reference_id あり → Firebase UID として直接使用（メール検索不要）
   - client_reference_id なし → メール検索フォールバック（後方互換）
     + 既存ユーザーに別の stripeCustomerId が紐づいていたら上書きを拒否

https://claude.ai/code/session_01XGNDj9PcEGGZx5QMGtEjEc