### PR TITLE
feat: ヘッダーのログインボタンと auth ルートを削除

### DIFF
--- a/src/components/my-header.riot
+++ b/src/components/my-header.riot
@@ -9,7 +9,6 @@
       <div class="header-actions">
         <slot name="menu-nav" />
         <slot name="menu-button" />
-        <auth-button />
         <language-switcher />
       </div>
     </div>

--- a/src/pages.js
+++ b/src/pages.js
@@ -31,18 +31,6 @@ export default [
     componentName: 'contact',
   },
   {
-    path: '/login',
-    label: 'LOGIN',
-    componentName: 'login',
-    hidden: true,
-  },
-  {
-    path: '/account',
-    label: 'ACCOUNT',
-    componentName: 'account',
-    hidden: true,
-  },
-  {
     path: '/terms',
     label: 'TERMS',
     componentName: 'terms',


### PR DESCRIPTION
Substack に認証・決済を委任する方針に合わせ、
サイト上でのログインが不要になったため UI から除去。

- my-header.riot: <auth-button /> を削除
- pages.js: /login, /account ルートを削除

auth-store.ts / firebase.ts / login.riot は将来の復活に備えて保持。

https://claude.ai/code/session_01XGNDj9PcEGGZx5QMGtEjEc